### PR TITLE
Set "name":"body" in requestBody parameters

### DIFF
--- a/src/main/java/io/github/manusant/ss/Swagger.java
+++ b/src/main/java/io/github/manusant/ss/Swagger.java
@@ -489,6 +489,7 @@ public class Swagger {
 
                             BodyParameter requestBody = new BodyParameter();
                             requestBody.description("Body object description");
+                            requestBody.name("body");
                             requestBody.setRequired(true);
                             requestBody.setSchema(model);
                             op.addParameter(requestBody);


### PR DESCRIPTION
With this the post parameters will have a `"name": "body"`

```
    "post": {
                "description": "Create a new Employee",
                "parameters": [
                    {
                        "description": "Body object description",
                        "in": "body",
                        "name": "body",
                        "required": true,
                        "schema": {
                            "$ref": "#/definitions/Employee"
                        }
                    }
                ],
                "responses": {
                    "200": {
                        "description": "successful operation",
                        "schema": {
                            "$ref": "#/definitions/Employee"
                        }
                    }
                },
                "tags": [
                    "employees"
                ]
        }
```

This is working for us, thanks for your work, I hope it helps.

Ref manusant/spark-swagger#4