### PR TITLE
Handle bounded types when getting collection type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,16 +33,10 @@
         <tag>HEAD</tag>
     </scm>
     <repositories>
-        <!-- To download spark-typify -->
+        <!-- To download spark-typify from github -->
         <repository>
-            <id>manusant-beerRepo</id>
-            <url>https://packagecloud.io/manusant/beerRepo/maven2</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
     <issueManagement>
@@ -80,7 +74,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.github.manusant</groupId>
+            <groupId>com.github.manusant</groupId>
             <artifactId>spark-typify</artifactId>
             <version>2.0.1</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,19 @@
         <developerConnection>scm:git:https://github.com/manusant/spark-swagger.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
-
+    <repositories>
+        <!-- To download spark-typify -->
+        <repository>
+            <id>manusant-beerRepo</id>
+            <url>https://packagecloud.io/manusant/beerRepo/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
     <issueManagement>
         <system>GitHub</system>
         <url>https://github.com/manusant/spark-swagger/issues</url>

--- a/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
+++ b/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
@@ -127,6 +127,7 @@ public class DefinitionsFactory {
                 || fieldClass.equals(String.class)
                 || fieldClass.equals(UUID.class)
                 || fieldClass.isArray()
+                || fieldClass.equals(Object.class)
                 || Collection.class.isAssignableFrom(fieldClass)
                 || File.class.isAssignableFrom(fieldClass)
                 || fieldClass.getCanonicalName().contains("java")

--- a/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
+++ b/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
@@ -174,16 +174,10 @@ public class DefinitionsFactory {
             } else if (actualType instanceof ParameterizedType) {
                 return (Class<?>) ((ParameterizedType) actualType).getActualTypeArguments()[0];
             }
-            // Attempt to extract the class if the collectionField represents
-            // a bounded type (e.g., T extends MyClass).
-            Type[] bounds = ((TypeVariableImpl<?>) actualType).getBounds();
-            if (bounds.length > 0) {
-                return (Class<?>) bounds[0];
-            }
         } catch (ClassCastException e) {
             LOGGER.error("Field mapping not supported. ", e);
         }
         // FIXME resolve actual type in strange collection types
-        return String.class;
+        return Object.class;
     }
 }

--- a/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
+++ b/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
@@ -6,6 +6,7 @@ import io.github.manusant.ss.model.ModelImpl;
 import io.github.manusant.ss.model.properties.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.reflect.generics.reflectiveObjects.TypeVariableImpl;
 
 import java.io.File;
 import java.lang.reflect.Field;
@@ -172,6 +173,12 @@ public class DefinitionsFactory {
                 return (Class<?>) actualType;
             } else if (actualType instanceof ParameterizedType) {
                 return (Class<?>) ((ParameterizedType) actualType).getActualTypeArguments()[0];
+            }
+            // Attempt to extract the class if the collectionField represents
+            // a bounded type (e.g., T extends MyClass).
+            Type[] bounds = ((TypeVariableImpl<?>) actualType).getBounds();
+            if (bounds.length > 0) {
+                return (Class<?>) bounds[0];
             }
         } catch (ClassCastException e) {
             LOGGER.error("Field mapping not supported. ", e);


### PR DESCRIPTION
This PR fixes manusant/spark-swagger#14 by adding some logic to check if there is a bounded type (e.g., `T extends MyClass`) for a collection field and handle it accordingly.