### PR TITLE
Various fixes/improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.manusant</groupId>
     <artifactId>spark-swagger</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <prerequisites>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.github.manusant</groupId>
             <artifactId>spark-typify</artifactId>
-            <version>2.0.2-SNAPSHOT</version>
+            <version>2.0.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>io.github.manusant</groupId>
+    <groupId>com.threatmetrix</groupId>
     <artifactId>spark-swagger</artifactId>
     <version>2.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -58,17 +58,29 @@
         <jacoco.api.version>0.7.6.201602180812</jacoco.api.version>
     </properties>
 
+    <!-- This will cause the deploy phase to publish the artifact(s) to the TMX repo. -->
     <distributionManagement>
-        <repository>
-            <id>github</id>
-            <name>Github OSS Packages</name>
-            <url>https://maven.pkg.github.com/manusant/spark-swagger</url>
-        </repository>
+      <repository>
+        <id>threatmetrix-release</id>
+        <url>https://rpms.cd.sac.int.threatmetrix.com/nexus/content/repositories/threatmetrix-release</url>
+        <releases>
+          <enabled>true</enabled>
+          <updatePolicy>always</updatePolicy>
+        </releases>
+      </repository>
+      <snapshotRepository>
+        <id>threatmetrix-snapshot</id>
+        <url>https://rpms.cd.sac.int.threatmetrix.com/nexus/content/repositories/threatmetrix-snapshot</url>
+        <snapshots>
+          <enabled>true</enabled>
+          <updatePolicy>always</updatePolicy>
+        </snapshots>
+      </snapshotRepository>
     </distributionManagement>
 
     <dependencies>
         <dependency>
-            <groupId>io.github.manusant</groupId>
+            <groupId>com.threatmetrix</groupId>
             <artifactId>spark-typify</artifactId>
             <version>2.0.2-SNAPSHOT</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -58,24 +58,12 @@
         <jacoco.api.version>0.7.6.201602180812</jacoco.api.version>
     </properties>
 
-    <!-- This will cause the deploy phase to publish the artifact(s) to the TMX repo. -->
     <distributionManagement>
-      <repository>
-        <id>threatmetrix-release</id>
-        <url>https://rpms.cd.sac.int.threatmetrix.com/nexus/content/repositories/threatmetrix-release</url>
-        <releases>
-          <enabled>true</enabled>
-          <updatePolicy>always</updatePolicy>
-        </releases>
-      </repository>
-      <snapshotRepository>
-        <id>threatmetrix-snapshot</id>
-        <url>https://rpms.cd.sac.int.threatmetrix.com/nexus/content/repositories/threatmetrix-snapshot</url>
-        <snapshots>
-          <enabled>true</enabled>
-          <updatePolicy>always</updatePolicy>
-        </snapshots>
-      </snapshotRepository>
+        <repository>
+            <id>github</id>
+            <name>Github OSS Packages</name>
+            <url>https://maven.pkg.github.com/manusant/spark-swagger</url>
+        </repository>
     </distributionManagement>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.manusant</groupId>
     <artifactId>spark-swagger</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.0.2</version>
     <packaging>jar</packaging>
 
     <prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.threatmetrix</groupId>
+    <groupId>io.github.manusant</groupId>
     <artifactId>spark-swagger</artifactId>
     <version>2.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -80,7 +80,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.threatmetrix</groupId>
+            <groupId>io.github.manusant</groupId>
             <artifactId>spark-typify</artifactId>
             <version>2.0.2-SNAPSHOT</version>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.github.manusant</groupId>
             <artifactId>spark-typify</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -118,6 +118,7 @@ public class SparkSwagger {
     }
 
     public ApiEndpoint getEndpoint(final String path) {
+        if (swagger.getApiEndpoints() == null) return null;
         for (final ApiEndpoint ep : swagger.getApiEndpoints()) {
             if (path.equals(ep.getEndpointDescriptor().getPath())) return ep;
         }

--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -220,7 +220,7 @@ public class SparkSwagger {
         info.title(infoConfig.getString("title"));
         info.termsOfService(infoConfig.getString("termsOfService"));
 
-        List<String> schemeStrings = Optional.ofNullable(infoConfig.getStringList("schemes")).orElseThrow(() -> new IllegalArgumentException("'spark-swagger.info.schemes' configuration is required"));
+/*        List<String> schemeStrings = Optional.ofNullable(infoConfig.getStringList("schemes")).orElseThrow(() -> new IllegalArgumentException("'spark-swagger.info.schemes' configuration is required"));
         List<Scheme> schemes = schemeStrings.stream()
                 .filter(s -> Scheme.forValue(s) != null)
                 .map(Scheme::forValue)
@@ -229,7 +229,7 @@ public class SparkSwagger {
             throw new IllegalArgumentException("At least one Scheme mus be specified. Use 'spark-swagger.info.schemes' property. spark-swagger.info.schemes =[\"HTTP\"]");
         }
         swagger.schemes(schemes);
-
+*/
         Config contactConfig = this.config.getConfig("spark-swagger.info.contact");
         if (contactConfig != null) {
             Contact contact = new Contact();

--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -117,6 +117,13 @@ public class SparkSwagger {
         new SwaggerHammer().prepareUi(config, swagger);
     }
 
+    public ApiEndpoint getEndpoint(final String path) {
+        for (final ApiEndpoint ep : swagger.getApiEndpoints()) {
+            if (path.equals(ep.getEndpointDescriptor().getPath())) return ep;
+        }
+        return null;
+    }
+
     public ApiEndpoint endpoint(final EndpointDescriptor.Builder descriptorBuilder) {
         return endpoint(descriptorBuilder, null);
     }

--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -227,16 +227,18 @@ public class SparkSwagger {
         info.title(infoConfig.getString("title"));
         info.termsOfService(infoConfig.getString("termsOfService"));
 
-/*        List<String> schemeStrings = Optional.ofNullable(infoConfig.getStringList("schemes")).orElseThrow(() -> new IllegalArgumentException("'spark-swagger.info.schemes' configuration is required"));
-        List<Scheme> schemes = schemeStrings.stream()
-                .filter(s -> Scheme.forValue(s) != null)
-                .map(Scheme::forValue)
-                .collect(Collectors.toList());
-        if (schemes.isEmpty()) {
-            throw new IllegalArgumentException("At least one Scheme mus be specified. Use 'spark-swagger.info.schemes' property. spark-swagger.info.schemes =[\"HTTP\"]");
+        if (infoConfig.hasPath("schemes")) {
+            List<String> schemeStrings = Optional.ofNullable(infoConfig.getStringList("schemes")).orElseThrow(() -> new IllegalArgumentException("'spark-swagger.info.schemes' configuration is required"));
+            List<Scheme> schemes = schemeStrings.stream()
+                    .filter(s -> Scheme.forValue(s) != null)
+                    .map(Scheme::forValue)
+                    .collect(Collectors.toList());
+            if (schemes.isEmpty()) {
+                throw new IllegalArgumentException("At least one Scheme mus be specified. Use 'spark-swagger.info.schemes' property. spark-swagger.info.schemes =[\"HTTP\"]");
+            }
+            swagger.schemes(schemes);
         }
-        swagger.schemes(schemes);
-*/
+
         Config contactConfig = this.config.getConfig("spark-swagger.info.contact");
         if (contactConfig != null) {
             Contact contact = new Contact();
@@ -245,12 +247,15 @@ public class SparkSwagger {
             contact.url(contactConfig.getString("url"));
             info.setContact(contact);
         }
-        Config licenseConfig = this.config.getConfig("spark-swagger.info.license");
-        if (licenseConfig != null) {
-            License license = new License();
-            license.name(licenseConfig.getString("name"));
-            license.url(licenseConfig.getString("url"));
-            info.setLicense(license);
+
+        if (this.config.hasPath("spark-swagger.info.license")) {
+            Config licenseConfig = this.config.getConfig("spark-swagger.info.license");
+            if (licenseConfig != null) {
+                License license = new License();
+                license.name(licenseConfig.getString("name"));
+                license.url(licenseConfig.getString("url"));
+                info.setLicense(license);
+            }
         }
         return info;
     }

--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -103,9 +103,8 @@ public class SparkSwagger {
         return new SparkSwagger(spark, confPath, null);
     }
 
-    public SparkSwagger version(final String version) {
-        this.version = version;
-        return this;
+    public static SparkSwagger of(final Service spark, final String confPath, final String version) {
+        return new SparkSwagger(spark, confPath, version);
     }
 
     public SparkSwagger ignores(Supplier<IgnoreSpec> confSupplier) {
@@ -118,10 +117,14 @@ public class SparkSwagger {
         new SwaggerHammer().prepareUi(config, swagger);
     }
 
+    public ApiEndpoint endpoint(final EndpointDescriptor.Builder descriptorBuilder) {
+        return endpoint(descriptorBuilder, null);
+    }
+
     public ApiEndpoint endpoint(final EndpointDescriptor.Builder descriptorBuilder, final Filter filter) {
         Optional.ofNullable(apiPath).orElseThrow(() -> new IllegalStateException("API Path must be specified in order to build REST endpoint"));
         EndpointDescriptor descriptor = descriptorBuilder.build();
-        spark.before(apiPath + descriptor.getPath() + "/*", filter);
+        if (filter != null) spark.before(apiPath + descriptor.getPath() + "/*", filter);
         ApiEndpoint apiEndpoint = new ApiEndpoint(this, descriptor);
         this.swagger.addApiEndpoint(apiEndpoint);
         return apiEndpoint;

--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -117,10 +117,10 @@ public class SparkSwagger {
         new SwaggerHammer().prepareUi(config, swagger);
     }
 
-    public ApiEndpoint getEndpoint(final String path) {
+    public ApiEndpoint getEndpoint(final String name) {
         if (swagger.getApiEndpoints() == null) return null;
         for (final ApiEndpoint ep : swagger.getApiEndpoints()) {
-            if (path.equals(ep.getEndpointDescriptor().getPath())) return ep;
+            if (name.equals(ep.getEndpointDescriptor().getTag().getName())) return ep;
         }
         return null;
     }

--- a/src/main/java/io/github/manusant/ss/Swagger.java
+++ b/src/main/java/io/github/manusant/ss/Swagger.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.github.manusant.spark.typify.spec.IgnoreSpec;
+import io.github.manusant.ss.descriptor.ParameterDescriptor;
 import io.github.manusant.ss.factory.DefinitionsFactory;
 import io.github.manusant.ss.factory.ParamsFactory;
 import io.github.manusant.ss.model.*;
@@ -475,48 +476,18 @@ public class Swagger {
                         // Supply Ignore configurations
                         DefinitionsFactory.ignoreSpec = this.ignoreSpec;
 
-                        if (methodDescriptor.getBody().getModel() != null) {
-
-                            final Model model = methodDescriptor.getBody().getModel();
+                        final ParameterDescriptor methodBody = methodDescriptor.getBody();
+                        if (methodBody != null && methodBody.getModel() != null) {
+                            final Model model = methodBody.getModel();
                             addDefinition(model.getTitle(), model);
                             BodyParameter requestBody = new BodyParameter();
-                            requestBody.name(methodDescriptor.getBody().getName());
-                            requestBody.description(methodDescriptor.getBody().getDescription());
-                            requestBody.setRequired(methodDescriptor.getBody().isRequired());
+                            requestBody.name(methodBody.getName());
+                            requestBody.description(methodBody.getDescription());
+                            requestBody.setRequired(methodBody.isRequired());
                             requestBody.setSchema(model);
-                            if (methodDescriptor.getBody().getExample() != null)
-                            {
-//                                requestBody.example("brent/json", methodDescriptor.getBody().getExample());
-                            }
                             op.addParameter(requestBody);
                         }
                         else if (methodDescriptor.getRequestType() != null) {
-
-                            Model model;
-/*                            final ObjectNode exampleJson = methodDescriptor.getBody().getExampleJson();
-                            if (exampleJson != null)
-                            {
-                                final ModelImpl jsonModel = new ModelImpl();
-                                jsonModel.setExample(exampleJson);
-                                jsonModel.setTitle(methodDescriptor.getBody().getObject().getSimpleName());
-
-                                final Map<String, Property> properties = new HashMap<>();
-                                final Iterator<Map.Entry<String, JsonNode>> exampleFields = exampleJson.fields();
-                                while (exampleFields.hasNext())
-                                {
-                                    final Map.Entry<String, JsonNode> field = exampleFields.next();
-                                    final String name = field.getKey().trim();
-                                    if (name == null || name.isEmpty()) continue;
-                                    field.getValue().getNodeType();
-                                    Property property = DefinitionsFactory.createProperty(name, field.getValue());
-                                    properties.put(name, property);
-                                }
-                                jsonModel.setProperties(properties);
-
-                                model = jsonModel;
-                            }
-                            else
-                            {*/
                                 // Process fields
                                 Map<String, Model> definitions = DefinitionsFactory.create(methodDescriptor.getRequestType());
                                 for (String key : definitions.keySet()) {
@@ -525,6 +496,7 @@ public class Swagger {
                                     }
                                 }
 
+                                Model model;
                                 if (definitions.isEmpty()) {
                                     Property property = DefinitionsFactory.createProperty(null, methodDescriptor.getRequestType());
                                     model = new PropertyModelConverter().propertyToModel(property);
@@ -533,12 +505,11 @@ public class Swagger {
                                     refModel.set$ref(methodDescriptor.getRequestType().getSimpleName());
                                     model = refModel;
                                 }
-//                            }
 
                             BodyParameter requestBody = new BodyParameter();
-                            requestBody.name(methodDescriptor.getBody().getName());
-                            requestBody.description(methodDescriptor.getBody().getDescription());
-                            requestBody.setRequired(methodDescriptor.getBody().isRequired());
+                            requestBody.name(methodBody != null? methodBody.getName() : "body");
+                            requestBody.description(methodBody != null? methodBody.getDescription() : "Body object description");
+                            requestBody.setRequired(methodBody != null? methodBody.isRequired() : true);
                             requestBody.setSchema(model);
                             op.addParameter(requestBody);
                         }

--- a/src/main/java/io/github/manusant/ss/Swagger.java
+++ b/src/main/java/io/github/manusant/ss/Swagger.java
@@ -462,6 +462,9 @@ public class Swagger {
                         op.tag(endpoint.getEndpointDescriptor().getTag().getName());
                         op.description(methodDescriptor.getDescription());
 
+                        if (methodDescriptor.getSummary() != null) op.summary(methodDescriptor.getSummary());
+                        if (methodDescriptor.getOperationId() != null) op.operationId(methodDescriptor.getOperationId());
+
                         List<Parameter> parameters = ParamsFactory.create(methodDescriptor.getPath(), methodDescriptor.getParameters());
                         op.setParameters(parameters);
 

--- a/src/main/java/io/github/manusant/ss/Swagger.java
+++ b/src/main/java/io/github/manusant/ss/Swagger.java
@@ -514,7 +514,14 @@ public class Swagger {
                             op.addParameter(requestBody);
                         }
 
-                        if (methodDescriptor.getResponseType() != null) {
+                        final Map<String, Response> responses = methodDescriptor.getResponses();
+                        if (responses != null && !responses.isEmpty()) {
+
+                            responses.forEach((code, response)->{
+                                op.addResponse(code, response);
+                            });
+                        }
+                        else if (methodDescriptor.getResponseType() != null) {
                             // Process fields
                             Map<String, Model> definitions = DefinitionsFactory.create(methodDescriptor.getResponseType());
                             for (String key : definitions.keySet()) {
@@ -535,8 +542,7 @@ public class Swagger {
                             Response responseBody = new Response();
                             responseBody.description("successful operation");
                             responseBody.setSchema(property);
-//                            op.addResponse("200", responseBody);
-                            op.addResponse("201", new Response().description("OK"));
+                            op.addResponse("200", responseBody);
 
                         } else {
                             Response responseBody = new Response();

--- a/src/main/java/io/github/manusant/ss/descriptor/EndpointDescriptor.java
+++ b/src/main/java/io/github/manusant/ss/descriptor/EndpointDescriptor.java
@@ -59,6 +59,7 @@ public class EndpointDescriptor {
     }
 
     public static final class Builder {
+        private String name;
         private String path;
         private String description;
         private ExternalDocs externalDoc;
@@ -68,6 +69,11 @@ public class EndpointDescriptor {
 
         public static Builder newBuilder() {
             return new Builder();
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
         }
 
         public Builder withPath(String path) {
@@ -85,7 +91,8 @@ public class EndpointDescriptor {
             return this;
         }
 
-        private String getTag() {
+        private String getName() {
+            if (name != null) return name;
             return path.contains("/") ? path.substring(1) : path;
         }
 
@@ -93,7 +100,7 @@ public class EndpointDescriptor {
             EndpointDescriptor endpointDescriptor = new EndpointDescriptor();
             endpointDescriptor.setPath(path);
             endpointDescriptor.setTag(Tag.newBuilder()
-                    .withName(getTag())
+                    .withName(getName())
                     .withDescription(description)
                     .withExternalDocs(externalDoc)
                     .build());

--- a/src/main/java/io/github/manusant/ss/descriptor/MethodDescriptor.java
+++ b/src/main/java/io/github/manusant/ss/descriptor/MethodDescriptor.java
@@ -16,6 +16,7 @@ public class MethodDescriptor {
 
     private HttpMethod method;
     private String path;
+    private String summary;
     private String description;
     private Class<?> requestType;
     private boolean requestAsCollection;
@@ -45,6 +46,13 @@ public class MethodDescriptor {
         this.path = path;
     }
 
+    public String getSummary() {
+        return summary;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
     public String getDescription() {
         return description;
     }
@@ -148,6 +156,7 @@ public class MethodDescriptor {
     public static final class Builder {
         private HttpMethod method;
         private String path;
+        private String summary;
         private String description;
         private Class requestType;
         private boolean requestAsCollection;
@@ -175,6 +184,11 @@ public class MethodDescriptor {
 
         public Builder withPath(String path) {
             this.path = path;
+            return this;
+        }
+
+        public Builder withSummary(String summary) {
+            this.summary = summary;
             return this;
         }
 
@@ -274,6 +288,7 @@ public class MethodDescriptor {
             MethodDescriptor methodDescriptor = new MethodDescriptor();
             methodDescriptor.setMethod(method);
             methodDescriptor.setPath(path);
+            methodDescriptor.setSummary(summary);
             methodDescriptor.setDescription(description);
             methodDescriptor.setRequestType(requestType);
             methodDescriptor.setRequestAsCollection(requestAsCollection);

--- a/src/main/java/io/github/manusant/ss/descriptor/MethodDescriptor.java
+++ b/src/main/java/io/github/manusant/ss/descriptor/MethodDescriptor.java
@@ -20,6 +20,7 @@ public class MethodDescriptor {
     private String description;
     private Class<?> requestType;
     private boolean requestAsCollection;
+    private ParameterDescriptor body;
     private Class<?> responseType;
     private boolean responseAsCollection;
     private String operationId;
@@ -75,6 +76,13 @@ public class MethodDescriptor {
 
     public void setRequestAsCollection(boolean requestAsCollection) {
         this.requestAsCollection = requestAsCollection;
+    }
+
+    public ParameterDescriptor getBody() {
+        return body;
+    }
+    public void setBody(ParameterDescriptor body) {
+        this.body = body;
     }
 
     public Class<?> getResponseType() {
@@ -160,6 +168,7 @@ public class MethodDescriptor {
         private String description;
         private Class requestType;
         private boolean requestAsCollection;
+        private ParameterDescriptor body;
         private Class responseType;
         private boolean responseAsCollection;
         private String operationId;
@@ -199,6 +208,11 @@ public class MethodDescriptor {
 
         public Builder withRequestType(Class requestType) {
             this.requestType = requestType;
+            return this;
+        }
+
+        public Builder withBody(ParameterDescriptor body ) {
+            this.body = body;
             return this;
         }
 
@@ -292,6 +306,7 @@ public class MethodDescriptor {
             methodDescriptor.setDescription(description);
             methodDescriptor.setRequestType(requestType);
             methodDescriptor.setRequestAsCollection(requestAsCollection);
+            methodDescriptor.setBody(body);
             methodDescriptor.setResponseType(responseType);
             methodDescriptor.setResponseAsCollection(responseAsCollection);
             methodDescriptor.setOperationId(operationId);

--- a/src/main/java/io/github/manusant/ss/descriptor/ParameterDescriptor.java
+++ b/src/main/java/io/github/manusant/ss/descriptor/ParameterDescriptor.java
@@ -2,6 +2,10 @@ package io.github.manusant.ss.descriptor;
 
 import java.util.Optional;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import io.github.manusant.ss.model.Model;
+
 /**
  * @author manusant
  */
@@ -17,7 +21,9 @@ public class ParameterDescriptor {
     private String description;
     private boolean required = false;
     private String example;
+    private ObjectNode exampleJson;
     private Boolean allowEmptyValue;
+    private Model model;
     private Class object;
     private Class collectionOf;
     private String defaultValue;
@@ -70,12 +76,29 @@ public class ParameterDescriptor {
         this.example = example;
     }
 
+    public ObjectNode getExampleJson() {
+        return exampleJson;
+    }
+    public ParameterDescriptor setExampleJson(ObjectNode exampleJson) {
+        this.exampleJson = exampleJson;
+        return this;
+    }
+
     public Boolean getAllowEmptyValue() {
         return allowEmptyValue;
     }
 
     public void setAllowEmptyValue(Boolean allowEmptyValue) {
         this.allowEmptyValue = allowEmptyValue;
+    }
+
+
+    public Model getModel() {
+        return model;
+    }
+
+    public void setModel(Model model) {
+        this.model = model;
     }
 
     public Class getObject() {
@@ -118,6 +141,7 @@ public class ParameterDescriptor {
         private boolean required = false;
         private String example;
         private Boolean allowEmptyValue;
+        private Model model;
         private Class object;
         private Class collectionOf;
         private String defaultValue;
@@ -169,6 +193,11 @@ public class ParameterDescriptor {
             return this;
         }
 
+        public Builder withModel(Model model) {
+            this.model = model;
+            return this;
+        }
+
         public Builder withObject(Class object) {
             this.object = object;
             return this;
@@ -193,6 +222,7 @@ public class ParameterDescriptor {
             parameterDescriptor.setRequired(required);
             parameterDescriptor.setExample(example);
             parameterDescriptor.setAllowEmptyValue(allowEmptyValue);
+            parameterDescriptor.setModel(model);
             parameterDescriptor.setObject(object);
             parameterDescriptor.setCollectionOf(collectionOf);
             parameterDescriptor.setDefaultValue(defaultValue);

--- a/src/main/java/io/github/manusant/ss/descriptor/ParameterDescriptor.java
+++ b/src/main/java/io/github/manusant/ss/descriptor/ParameterDescriptor.java
@@ -21,7 +21,6 @@ public class ParameterDescriptor {
     private String description;
     private boolean required = false;
     private String example;
-    private ObjectNode exampleJson;
     private Boolean allowEmptyValue;
     private Model model;
     private Class object;
@@ -74,14 +73,6 @@ public class ParameterDescriptor {
 
     public void setExample(String example) {
         this.example = example;
-    }
-
-    public ObjectNode getExampleJson() {
-        return exampleJson;
-    }
-    public ParameterDescriptor setExampleJson(ObjectNode exampleJson) {
-        this.exampleJson = exampleJson;
-        return this;
     }
 
     public Boolean getAllowEmptyValue() {

--- a/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
+++ b/src/main/java/io/github/manusant/ss/factory/DefinitionsFactory.java
@@ -168,7 +168,7 @@ public class DefinitionsFactory {
             case NULL:
             case POJO:
         }
-        throw new IllegalArgumentException("Unsupported JsonNode type (" +node.getNodeType() +") - " +node.toString());
+        return null;
     }
 
     private static boolean isRef(Class<?> fieldClass) {

--- a/src/main/java/io/github/manusant/ss/factory/ParamsFactory.java
+++ b/src/main/java/io/github/manusant/ss/factory/ParamsFactory.java
@@ -119,6 +119,7 @@ public class ParamsFactory {
         parameter.setName(parameterDescriptor.getName());
         parameter.setDescription(parameterDescriptor.getDescription());
         parameter.setPattern(parameterDescriptor.getPattern());
+        parameter.setRequired(parameterDescriptor.isRequired());
         parameter.setExample(parameterDescriptor.getExample());
         parameter.setAllowEmptyValue(parameterDescriptor.getAllowEmptyValue());
         parameter.setDefaultValue(parameterDescriptor.getDefaultValue());

--- a/src/main/java/io/github/manusant/ss/model/AbstractModel.java
+++ b/src/main/java/io/github/manusant/ss/model/AbstractModel.java
@@ -11,6 +11,7 @@ public abstract class AbstractModel implements Model {
     private ExternalDocs externalDocs;
     private String reference;
     private String title;
+    private Class<?> classType;
     private Map<String, Object> vendorExtensions = new LinkedHashMap<String, Object>();
     private Xml xml;
 
@@ -31,6 +32,16 @@ public abstract class AbstractModel implements Model {
     @Override
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    @Override
+    public Class<?> getClassType() {
+        return classType;
+    }
+
+    @Override
+    public void setClassType(Class<?> classType) {
+        this.classType = classType;
     }
 
     @JsonAnyGetter
@@ -54,6 +65,7 @@ public abstract class AbstractModel implements Model {
         cloned.externalDocs = this.externalDocs;
         cloned.reference = reference;
         cloned.title = title;
+        cloned.classType = classType;
         if (vendorExtensions == null) {
             cloned.vendorExtensions = vendorExtensions;
         } else {
@@ -120,6 +132,13 @@ public abstract class AbstractModel implements Model {
                 return false;
             }
         } else if (!title.equals(other.title)) {
+            return false;
+        }
+        if (classType == null) {
+            if (other.classType != null) {
+                return false;
+            }
+        } else if (!classType.equals(other.classType)) {
             return false;
         }
         if (reference == null) {

--- a/src/main/java/io/github/manusant/ss/model/AbstractModel.java
+++ b/src/main/java/io/github/manusant/ss/model/AbstractModel.java
@@ -11,7 +11,7 @@ public abstract class AbstractModel implements Model {
     private ExternalDocs externalDocs;
     private String reference;
     private String title;
-    private Class<?> classType;
+    private Class<?> typeClass;
     private Map<String, Object> vendorExtensions = new LinkedHashMap<String, Object>();
     private Xml xml;
 
@@ -35,13 +35,13 @@ public abstract class AbstractModel implements Model {
     }
 
     @Override
-    public Class<?> getClassType() {
-        return classType;
+    public Class<?> getTypeClass() {
+        return typeClass;
     }
 
     @Override
-    public void setClassType(Class<?> classType) {
-        this.classType = classType;
+    public void setTypeClass(Class<?> typeClass) {
+        this.typeClass = typeClass;
     }
 
     @JsonAnyGetter
@@ -65,7 +65,7 @@ public abstract class AbstractModel implements Model {
         cloned.externalDocs = this.externalDocs;
         cloned.reference = reference;
         cloned.title = title;
-        cloned.classType = classType;
+        cloned.typeClass = typeClass;
         if (vendorExtensions == null) {
             cloned.vendorExtensions = vendorExtensions;
         } else {
@@ -96,6 +96,8 @@ public abstract class AbstractModel implements Model {
                 + ((reference == null) ? 0 : reference.hashCode());
         result = prime * result
                 + ((title == null) ? 0 : title.hashCode());
+        result = prime * result
+                + ((typeClass == null) ? 0 : typeClass.hashCode());
         result = prime * result
                 + ((xml == null) ? 0 : xml.hashCode());
         return result;
@@ -134,11 +136,11 @@ public abstract class AbstractModel implements Model {
         } else if (!title.equals(other.title)) {
             return false;
         }
-        if (classType == null) {
-            if (other.classType != null) {
+        if (typeClass == null) {
+            if (other.typeClass != null) {
                 return false;
             }
-        } else if (!classType.equals(other.classType)) {
+        } else if (!typeClass.equals(other.typeClass)) {
             return false;
         }
         if (reference == null) {

--- a/src/main/java/io/github/manusant/ss/model/Model.java
+++ b/src/main/java/io/github/manusant/ss/model/Model.java
@@ -27,6 +27,10 @@ public interface Model {
 
     void setReference(String reference);
 
+    Class<?> getClassType();
+
+    void setClassType(Class<?> classType);
+
     Object clone();
 
     Map<String, Object> getVendorExtensions();

--- a/src/main/java/io/github/manusant/ss/model/Model.java
+++ b/src/main/java/io/github/manusant/ss/model/Model.java
@@ -27,9 +27,9 @@ public interface Model {
 
     void setReference(String reference);
 
-    Class<?> getClassType();
+    Class<?> getTypeClass();
 
-    void setClassType(Class<?> classType);
+    void setTypeClass(Class<?> typeClass);
 
     Object clone();
 

--- a/src/main/java/io/github/manusant/ss/model/RefModel.java
+++ b/src/main/java/io/github/manusant/ss/model/RefModel.java
@@ -17,7 +17,7 @@ public class RefModel implements Model {
     private Map<String, Property> properties;
     private Object example;
     private String title;
-    private Class<?> classType;
+    private Class<?> typeClass;
 
     public RefModel() {
     }
@@ -44,13 +44,13 @@ public class RefModel implements Model {
     }
 
     @Override
-    public Class<?> getClassType() {
-        return classType;
+    public Class<?> getTypeClass() {
+        return typeClass;
     }
 
     @Override
-    public void setClassType(Class<?> classType) {
-        this.classType = classType;
+    public void setTypeClass(Class<?> typeClass) {
+        this.typeClass = typeClass;
     }
 
     // not allowed in a $ref
@@ -115,7 +115,7 @@ public class RefModel implements Model {
         cloned.properties = this.properties;
         cloned.example = this.example;
         cloned.title = this.title;
-        cloned.classType = this.classType;
+        cloned.typeClass = this.typeClass;
         return cloned;
     }
 
@@ -131,6 +131,10 @@ public class RefModel implements Model {
         int result = 1;
         result = prime * result
                 + ((description == null) ? 0 : description.hashCode());
+        result = prime * result
+                + ((title == null) ? 0 : title.hashCode());
+        result = prime * result
+                + ((typeClass == null) ? 0 : typeClass.hashCode());
         result = prime * result + ((example == null) ? 0 : example.hashCode());
         result = prime * result
                 + ((externalDocs == null) ? 0 : externalDocs.hashCode());
@@ -194,11 +198,11 @@ public class RefModel implements Model {
         } else if (!title.equals(other.title)) {
             return false;
         }
-        if (classType == null) {
-            if (other.classType != null) {
+        if (typeClass == null) {
+            if (other.typeClass != null) {
                 return false;
             }
-        } else if (!classType.equals(other.classType)) {
+        } else if (!typeClass.equals(other.typeClass)) {
             return false;
         }
         return true;

--- a/src/main/java/io/github/manusant/ss/model/RefModel.java
+++ b/src/main/java/io/github/manusant/ss/model/RefModel.java
@@ -17,6 +17,7 @@ public class RefModel implements Model {
     private Map<String, Property> properties;
     private Object example;
     private String title;
+    private Class<?> classType;
 
     public RefModel() {
     }
@@ -40,6 +41,16 @@ public class RefModel implements Model {
     @Override
     public void setTitle(String title) {
         this.title = title;
+    }
+
+    @Override
+    public Class<?> getClassType() {
+        return classType;
+    }
+
+    @Override
+    public void setClassType(Class<?> classType) {
+        this.classType = classType;
     }
 
     // not allowed in a $ref
@@ -103,7 +114,8 @@ public class RefModel implements Model {
         cloned.description = this.description;
         cloned.properties = this.properties;
         cloned.example = this.example;
-
+        cloned.title = this.title;
+        cloned.classType = this.classType;
         return cloned;
     }
 
@@ -173,6 +185,20 @@ public class RefModel implements Model {
                 return false;
             }
         } else if (!genericRef.equals(other.genericRef)) {
+            return false;
+        }
+        if (title == null) {
+            if (other.title != null) {
+                return false;
+            }
+        } else if (!title.equals(other.title)) {
+            return false;
+        }
+        if (classType == null) {
+            if (other.classType != null) {
+                return false;
+            }
+        } else if (!classType.equals(other.classType)) {
             return false;
         }
         return true;

--- a/src/main/java/io/github/manusant/ss/model/Response.java
+++ b/src/main/java/io/github/manusant/ss/model/Response.java
@@ -73,23 +73,23 @@ public class Response {
         return this;
     }
 
-/*
+
     public Model getResponseSchema() {
         if(schemaAsModel == null && schemaAsProperty != null) {
             return new PropertyModelConverter().propertyToModel(schemaAsProperty);
         }
         return schemaAsModel;
     }
-*/
 
-/*    public void setResponseSchema(Model model) {
+
+    public void setResponseSchema(Model model) {
         this.schemaAsModel = model;
-    }*/
+    }
 
-    /*public Response responseSchema(Model model) {
+    public Response responseSchema(Model model) {
         this.setResponseSchema(model);
         return this;
-    }*/
+    }
 
     public Map<String, Object> getExamples() {
         return this.examples;

--- a/src/main/java/io/github/manusant/ss/model/parameters/AbstractSerializableParameter.java
+++ b/src/main/java/io/github/manusant/ss/model/parameters/AbstractSerializableParameter.java
@@ -387,6 +387,11 @@ public abstract class AbstractSerializableParameter<T extends AbstractSerializab
     }
 
     @JsonProperty("x-example")
+    public Object getXExample() {
+        return getExample();
+    }
+
+    @JsonProperty("example")
     public Object getExample() {
         if (example == null) {
             return null;

--- a/src/main/java/io/github/manusant/ss/model/parameters/AbstractSerializableParameter.java
+++ b/src/main/java/io/github/manusant/ss/model/parameters/AbstractSerializableParameter.java
@@ -12,9 +12,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@JsonPropertyOrder({"name", "in", "description", "required", "type", "items", "collectionFormat", "default", "maximum",
+@JsonPropertyOrder({"name", "in", "description", "required", "type", "items", "format", "collectionFormat", "default", "maximum",
         "exclusiveMaximum", "minimum", "exclusiveMinimum", "maxLength", "minLength", "pattern", "maxItems", "minItems",
-        "uniqueItems", "multipleOf"})
+        "uniqueItems", "multipleOf", "example"})
 public abstract class AbstractSerializableParameter<T extends AbstractSerializableParameter<T>> extends AbstractParameter implements SerializableParameter {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractSerializableParameter.class);
     protected String type;

--- a/src/main/java/io/github/manusant/ss/model/parameters/BodyParameter.java
+++ b/src/main/java/io/github/manusant/ss/model/parameters/BodyParameter.java
@@ -50,6 +50,11 @@ public class BodyParameter extends AbstractParameter implements Parameter {
     }
 
     @JsonProperty("x-examples")
+    public Map<String, String> getXExamples() {
+        return examples;
+    }
+
+    @JsonProperty("examples")
     public Map<String, String> getExamples() {
         return examples;
     }

--- a/src/main/java/io/github/manusant/ss/model/utils/PropertyModelConverter.java
+++ b/src/main/java/io/github/manusant/ss/model/utils/PropertyModelConverter.java
@@ -147,6 +147,7 @@ public class PropertyModelConverter {
             RefProperty ref = (RefProperty) property;
             RefModel refModel = new RefModel(ref.get$ref());
             refModel.setTitle(title);
+            refModel.setExample(property.getExample());
             return refModel;
         }
 

--- a/src/main/java/io/github/manusant/ss/model/utils/PropertyModelConverter.java
+++ b/src/main/java/io/github/manusant/ss/model/utils/PropertyModelConverter.java
@@ -134,6 +134,7 @@ public class PropertyModelConverter {
         String type = property.getType();
         String format = property.getFormat();
         String example = null;
+        String title = property.getTitle();
 
         /*Object obj = property.getExample();
         if (obj != null) {
@@ -145,6 +146,7 @@ public class PropertyModelConverter {
         if(property instanceof RefProperty){
             RefProperty ref = (RefProperty) property;
             RefModel refModel = new RefModel(ref.get$ref());
+            refModel.setTitle(title);
             return refModel;
         }
 
@@ -189,6 +191,7 @@ public class PropertyModelConverter {
 
         model.setDescription(description);
         model.setExample(property.getExample());//example
+        model.setTitle(title);
         model.setName(name);
         model.setXml(xml);
         model.setType(type);


### PR DESCRIPTION
Added ability to set version.
Added ability to set operation summary and ID.
Added ability to create endpoint using EndpointDescriptor and not have to also create a filter.
Added ability to create model properties from JsonNode objects.
Added ability to pass model with parameter rather than having it generated when parsing definitions.
Added ability to make query parameters required.
Removed requirement for schemes and license settings in config file.
Enabled displaying example values for parameters.
Added support for using MethodDescriptor responses map.
Added typeClass ("type" was already taken) to Model interface so a method can have multiple responses with different types that get added to the model definition list.
Added ability to set endpoint name differently from its path.
