### PR TITLE
Support for disabling the configuration of the external static file location

### DIFF
--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -39,6 +39,10 @@ public class SparkSwagger {
     private String version;
 
     private SparkSwagger(final Service spark, final String confPath, final String version) {
+        this(spark, confPath, version, true, true);
+    }
+
+    private SparkSwagger(final Service spark, final String confPath, final String version, final boolean configDocRoute, final boolean enableCors) {
         this.spark = spark;
         this.version = version;
         this.swagger = new Swagger();
@@ -48,39 +52,40 @@ public class SparkSwagger {
         this.swagger.setExternalDocs(ExternalDocs.newBuilder().build());
         this.swagger.setHost(getHost());
         this.swagger.setInfo(getInfo());
-        configDocRoute();
-    }
 
-    private void configDocRoute() {
-        // Configure static mapping
         String uiFolder = SwaggerHammer.getUiFolder(this.apiPath);
         SwaggerHammer.createDir(SwaggerHammer.getSwaggerUiFolder());
         SwaggerHammer.createDir(uiFolder);
-        spark.externalStaticFileLocation(uiFolder);
-        LOGGER.debug("Spark-Swagger: UI folder deployed at {}", uiFolder);
+        if (configDocRoute) {
+            // Configure static mapping
+            spark.externalStaticFileLocation(uiFolder);
+            LOGGER.debug("Spark-Swagger: UI folder deployed at {}", uiFolder);
+        }
 
-        // Enable CORS
-        spark.options("/*",
-                (request, response) -> {
+        if (enableCors) {
+            // Enable CORS
+            spark.options("/*",
+                    (request, response) -> {
 
-                    String accessControlRequestHeaders = request
-                            .headers("Access-Control-Request-Headers");
-                    if (accessControlRequestHeaders != null) {
-                        response.header("Access-Control-Allow-Headers",
-                                accessControlRequestHeaders);
-                    }
+                        String accessControlRequestHeaders = request
+                                .headers("Access-Control-Request-Headers");
+                        if (accessControlRequestHeaders != null) {
+                            response.header("Access-Control-Allow-Headers",
+                                    accessControlRequestHeaders);
+                        }
 
-                    String accessControlRequestMethod = request
-                            .headers("Access-Control-Request-Method");
-                    if (accessControlRequestMethod != null) {
-                        response.header("Access-Control-Allow-Methods",
-                                accessControlRequestMethod);
-                    }
-                    return "OK";
-                });
+                        String accessControlRequestMethod = request
+                                .headers("Access-Control-Request-Method");
+                        if (accessControlRequestMethod != null) {
+                            response.header("Access-Control-Allow-Methods",
+                                    accessControlRequestMethod);
+                        }
+                        return "OK";
+                    });
 
-        spark.before((request, response) -> response.header("Access-Control-Allow-Origin", "*"));
-        LOGGER.debug("Spark-Swagger: CORS enabled and allow Origin *");
+            spark.before((request, response) -> response.header("Access-Control-Allow-Origin", "*"));
+            LOGGER.debug("Spark-Swagger: CORS enabled and allow Origin *");
+        }
     }
 
     public String getApiPath() {
@@ -105,6 +110,10 @@ public class SparkSwagger {
 
     public static SparkSwagger of(final Service spark, final String confPath, final String version) {
         return new SparkSwagger(spark, confPath, version);
+    }
+
+    public static SparkSwagger of(final Service spark, final String confPath, final String version, final boolean configDocRoute, final boolean enableCors) {
+        return new SparkSwagger(spark, confPath, version, configDocRoute, enableCors);
     }
 
     public SparkSwagger ignores(Supplier<IgnoreSpec> confSupplier) {

--- a/src/main/java/io/github/manusant/ss/SparkSwagger.java
+++ b/src/main/java/io/github/manusant/ss/SparkSwagger.java
@@ -42,7 +42,7 @@ public class SparkSwagger {
         this(spark, confPath, version, true, true);
     }
 
-    private SparkSwagger(final Service spark, final String confPath, final String version, final boolean configDocRoute, final boolean enableCors) {
+    private SparkSwagger(final Service spark, final String confPath, final String version, final boolean configStaticMapping, final boolean enableCors) {
         this.spark = spark;
         this.version = version;
         this.swagger = new Swagger();
@@ -52,11 +52,15 @@ public class SparkSwagger {
         this.swagger.setExternalDocs(ExternalDocs.newBuilder().build());
         this.swagger.setHost(getHost());
         this.swagger.setInfo(getInfo());
+        configDocRoute(configStaticMapping, enableCors);
+    }
 
+    private void configDocRoute(final boolean configStaticMapping, final boolean enableCors) {
         String uiFolder = SwaggerHammer.getUiFolder(this.apiPath);
         SwaggerHammer.createDir(SwaggerHammer.getSwaggerUiFolder());
         SwaggerHammer.createDir(uiFolder);
-        if (configDocRoute) {
+
+        if (configStaticMapping) {
             // Configure static mapping
             spark.externalStaticFileLocation(uiFolder);
             LOGGER.debug("Spark-Swagger: UI folder deployed at {}", uiFolder);
@@ -112,7 +116,7 @@ public class SparkSwagger {
         return new SparkSwagger(spark, confPath, version);
     }
 
-    public static SparkSwagger of(final Service spark, final String confPath, final String version, final boolean configDocRoute, final boolean enableCors) {
+    public static SparkSwagger of(final Service spark, final String confPath, final String version, final boolean configStaticMapping, final boolean enableCors) {
         return new SparkSwagger(spark, confPath, version, configDocRoute, enableCors);
     }
 

--- a/src/main/java/io/github/manusant/ss/SwaggerHammer.java
+++ b/src/main/java/io/github/manusant/ss/SwaggerHammer.java
@@ -155,6 +155,7 @@ public class SwaggerHammer {
     }
 
     public static String getUiFolder(String basePath) {
+        if (basePath.isEmpty()) return getSwaggerUiFolder();
         return System.getProperty("java.io.tmpdir") + "/swagger-ui" + (basePath.startsWith("/") ? "" : "/") + basePath + (basePath.endsWith("/") ? "" : "/");
     }
 


### PR DESCRIPTION
Added support for disabling the configuration of the external static file location, so it can be done externally (and therefore won't fail if filters/routes that need to run before the external files consume a request have already been created).
Also added support for having empty base path.