### PR TITLE
Fix UI folder path

### DIFF
--- a/src/main/java/io/github/manusant/ss/SwaggerHammer.java
+++ b/src/main/java/io/github/manusant/ss/SwaggerHammer.java
@@ -187,7 +187,7 @@ public class SwaggerHammer {
     }
 
     public static String getSwaggerUiFolder() {
-        return System.getProperty("java.io.tmpdir") + "swagger-ui/";
+        return Paths.get(System.getProperty("java.io.tmpdir"), "swagger-ui/").toString();
     }
 
     public static void createDir(final String path) {

--- a/src/main/java/io/github/manusant/ss/SwaggerHammerTest.java
+++ b/src/main/java/io/github/manusant/ss/SwaggerHammerTest.java
@@ -1,2 +1,0 @@
-package io.github.manusant.ss;public class SwaggerHammerTest {
-}

--- a/src/main/java/io/github/manusant/ss/SwaggerHammerTest.java
+++ b/src/main/java/io/github/manusant/ss/SwaggerHammerTest.java
@@ -1,0 +1,2 @@
+package io.github.manusant.ss;public class SwaggerHammerTest {
+}


### PR DESCRIPTION
## Hey, I just made a Pull Request!

This PR fixes #31 (I think...) and a flaw in the calculation of the temporary folder for `swagger-ui` in some linux environments.
An example of erroneous path computation can be found at https://github.com/ibi-group/otp-middleware/runs/5237239882?check_suite_focus=true#step:8:184.

To test, run the unit test outlined below (let me know if the test file needs to be at a particular location):
```java
import ...

public class SwaggerHammerTest {
    @Test
    void ensureSwaggerUiExists() {
        assertTrue(new File(SwaggerHammer.getSwaggerUiFolder()).exists());
    }
}
```

#### :heavy_check_mark: Checklist

- [na] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes. => partial test file provided above.
- [na] Screenshots attached (for UI changes).
- [na] Provided new Configurations and updated documentation accordingly
